### PR TITLE
Makes parse_existing methods not choke when datetime fields are absent:

### DIFF
--- a/voter/models.py
+++ b/voter/models.py
@@ -66,9 +66,10 @@ class NCVHis(models.Model):
 
     @staticmethod
     def parse_existing(row):
-        election_lbl_str = row['election_lbl']
-        election_lbl_dt = datetime.strptime(election_lbl_str, '%Y-%m-%d')
-        row['election_lbl'] = election_lbl_dt.date()
+        election_lbl_str = row.get('election_lbl')
+        if election_lbl_str:
+            election_lbl_dt = datetime.strptime(election_lbl_str, '%Y-%m-%d')
+            row['election_lbl'] = election_lbl_dt.date()
         return row
 
     ncid = models.CharField('ncid', max_length=12, db_index=True)
@@ -116,9 +117,10 @@ class NCVoter(models.Model):
 
     @staticmethod
     def parse_existing(row):
-        registr_dt_str = row['registr_dt']
-        registr_dt = datetime.strptime(registr_dt_str, '%Y-%m-%d')
-        row['registr_dt'] = registr_dt.date()
+        registr_dt_str = row.get('registr_dt')
+        if registr_dt_str:
+            registr_dt = datetime.strptime(registr_dt_str, '%Y-%m-%d')
+            row['registr_dt'] = registr_dt.date()
         return row
 
     ncid = models.CharField('ncid', max_length=12, unique=True, db_index=True)


### PR DESCRIPTION
These fields, while required on the incoming data, may not be present in
the existing data being parsed, which will contain partial data when
change tracking is looking at modified fields only.

This was originally an oversight on my part. I'm uncertain how this seemed to work in my testing.

I've manually applied this change on the server to test it out and it seems to be working. I no longer have access rights to the repo (and that's fine) so I've made this fork so I can demonstrate the changes.

As a separate note, we should probably add some configuration to the crontab so that it will email someone when the process errors out so we can catch this sort of thing sooner in the future.