### PR TITLE
Update include_role syntax and add role to inventory

### DIFF
--- a/deployment/playbooks/papertrail.yml
+++ b/deployment/playbooks/papertrail.yml
@@ -5,7 +5,8 @@
   tasks:
   - when: papertrail_host and papertrail_port
     block:
-    - include_role: papertrail
+    - include_role:
+        name: papertrail
     - name: Override papertrail config file so more of our log files will be included, including output from Django
       template:
         src: templates/log_files.yml.j2


### PR DESCRIPTION
Got this error when I tried to run the original version:
```
$ fab production deploy
[localhost] local: ansible-galaxy install -i -r deployment/requirements.yml
...
ERROR! 'name' is a required field for include_role.

Fatal error: local() encountered an error (return code 4) while executing 'ansible-playbook -u vkurup -i deployment/environments/production/inventory deployment/playbooks/site.yml'

Aborting.
```
After fixing that syntax, the role still didn't get run because we need to apply it to particular hosts in the inventory file.