### PR TITLE
DIS-246 Add voter_fetch_snapshot tests

### DIFF
--- a/voter/management/commands/voter_fetch.py
+++ b/voter/management/commands/voter_fetch.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 import os
-from zipfile import ZipFile
+import subprocess
 from enum import Enum
 
 from django.core.management import BaseCommand
@@ -37,13 +37,11 @@ def write_stream(stream_response, filename):
 
 
 def extract_and_remove_file(filename):
-    try:
-        with ZipFile(filename, "r") as z:
-            z.extractall(os.path.dirname(filename))
-    except IOError:
+    return_code = subprocess.call(['unzip', filename, '-d', os.path.dirname(filename)])
+    if return_code != 0:
         return False
-    finally:
-        os.remove(filename)
+    # if unzip failed, then don't rm file so we can investigate
+    os.remove(filename)
     return True
 
 
@@ -68,7 +66,7 @@ def attempt_fetch_and_write_new_zip(url, base_path):
     return (status_code, etag, now, target_filename)
 
 
-def process_new_zip(url, base_path, label, county_num):
+def process_new_zip(url, base_path, label, county_num=None):
     print("Fetching {0}".format(label))
     fetch_status_code, etag, created_time, target_filename = attempt_fetch_and_write_new_zip(url, base_path)
     if fetch_status_code == FETCH_STATUS_CODES.CODE_OK:
@@ -86,12 +84,10 @@ def process_new_zip(url, base_path, label, county_num):
                 data_file_kind = FileTracker.DATA_FILE_KIND_NCVOTER
             else:
                 data_file_kind = FileTracker.DATA_FILE_KIND_NCVHIS
-            ft = FileTracker.objects.create(
-                etag=etag, filename=target_filename[:-3] + 'txt',
+            FileTracker.objects.create(
+                etag=etag, filename=result_filename,
                 county_num=county_num, created=created_time,
                 data_file_kind=data_file_kind)
-            if not ft:
-                return FETCH_STATUS_CODES.CODE_DB_FAILURE
         else:
             print("Unable to unzip {0}".format(target_filename))
             return FETCH_STATUS_CODES.CODE_WRITE_FAILURE

--- a/voter/management/commands/voter_fetch.py
+++ b/voter/management/commands/voter_fetch.py
@@ -40,9 +40,10 @@ def extract_and_remove_file(filename):
     return_code = subprocess.call(['unzip', filename, '-d', os.path.dirname(filename)])
     if return_code != 0:
         return False
-    # if unzip failed, then don't rm file so we can investigate
-    os.remove(filename)
-    return True
+    else:
+        # if unzip failed, then don't rm file so we can investigate
+        os.remove(filename)
+        return True
 
 
 def attempt_fetch_and_write_new_zip(url, base_path):

--- a/voter/management/commands/voter_fetch_snapshot.py
+++ b/voter/management/commands/voter_fetch_snapshot.py
@@ -52,9 +52,10 @@ def extract_and_remove_file(filename):
     return_code = subprocess.call(['unzip', filename, '-d', os.path.dirname(filename)])
     if return_code != 0:
         return False
-    # if unzip failed, then don't rm file so we can investigate
-    os.remove(filename)
-    return True
+    else:
+        # if unzip failed, then don't rm file so we can investigate
+        os.remove(filename)
+        return True
 
 
 def attempt_fetch_and_write_new_zip(url, base_path):

--- a/voter/tests/test_api.py
+++ b/voter/tests/test_api.py
@@ -1,7 +1,7 @@
-from datetime import datetime
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from django.utils import timezone
 
 from voter import models
 from voter.views import changes
@@ -15,7 +15,7 @@ class APIChangesTests(TestCase):
         return request
 
     def make_change(self, ncid, data):
-        now = datetime.now()
+        now = timezone.now()
         ft = models.FileTracker.objects.get_or_create(filename="data.txt", defaults={'created': now})[0]
         voter = models.NCVoter.objects.get_or_create(ncid=ncid)[0]
         lineno = models.ChangeTracker.objects.filter(file_tracker=ft).count()

--- a/voter/tests/test_fetch.py
+++ b/voter/tests/test_fetch.py
@@ -6,9 +6,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from voter.models import FileTracker
-from voter.management.commands.voter_fetch_snapshot import derive_target_folder, get_etag_and_zip_stream, \
-    write_stream, extract_and_remove_file, attempt_fetch_and_write_new_zip, FETCH_STATUS_CODES, \
-    process_new_zip
+from voter.management.commands import voter_fetch_snapshot, voter_fetch
 
 
 class VoterFetchTest(TestCase):
@@ -23,7 +21,7 @@ class VoterFetchTest(TestCase):
         "creates a folder path given a base_path and a date"
         now = timezone.now()
         expected_result = '{}/{}'.format(self.base_path, now.strftime('%Y-%m-%dT%H:%M:%S:%s'))
-        result = derive_target_folder(self.base_path, now)
+        result = voter_fetch_snapshot.derive_target_folder(self.base_path, now)
         self.assertEqual(result, expected_result)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.requests.get')
@@ -31,7 +29,7 @@ class VoterFetchTest(TestCase):
         "returns the URL response and its etag header"
         mock_response = mock_get.return_value
         mock_response.headers = {'etag': self.etag}
-        result = get_etag_and_zip_stream(self.url)
+        result = voter_fetch_snapshot.get_etag_and_zip_stream(self.url)
         self.assertEqual(result, (self.etag, mock_response))
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.os.makedirs')
@@ -43,7 +41,7 @@ class VoterFetchTest(TestCase):
         rsp.iter_content.return_value = ['some', 'content']
         filename = 'foo/bar.txt'
         with mock.patch('voter.management.commands.voter_fetch_snapshot.open', mock_open, create=True):
-            result = write_stream(rsp, filename)
+            result = voter_fetch_snapshot.write_stream(rsp, filename)
         mock_open.assert_called_once_with(filename, 'wb')
         self.assertEqual(result, True)
 
@@ -52,7 +50,7 @@ class VoterFetchTest(TestCase):
         rsp = mock.Mock()
         # filename at root of filesystem should not be writable, so will generate IOError
         filename = '/foo.txt'
-        result = write_stream(rsp, filename)
+        result = voter_fetch_snapshot.write_stream(rsp, filename)
         self.assertEqual(result, False)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.subprocess.call')
@@ -60,7 +58,7 @@ class VoterFetchTest(TestCase):
     def test_extract_and_remove_file(self, mock_remove, mock_unzip):
         mock_unzip.return_value = 0
         filename = 'foo/bar.zip'
-        result = extract_and_remove_file(filename)
+        result = voter_fetch_snapshot.extract_and_remove_file(filename)
         self.assertEqual(result, True)
         mock_unzip.assert_called_once_with(['unzip', filename, '-d', 'foo'])
         mock_remove.assert_called_once_with(filename)
@@ -68,7 +66,7 @@ class VoterFetchTest(TestCase):
     @mock.patch('voter.management.commands.voter_fetch_snapshot.os.remove')
     def test_extract_and_remove_file_ioerror(self, mock_remove):
         filename = 'foo/bar.zip'
-        result = extract_and_remove_file(filename)
+        result = voter_fetch_snapshot.extract_and_remove_file(filename)
         self.assertEqual(result, False)
         # unzip failed, so we shouldn't have tried to remove the file
         mock_remove.assert_not_called()
@@ -97,11 +95,11 @@ class VoterFetchTest(TestCase):
     @mock.patch('voter.management.commands.voter_fetch_snapshot.get_etag_and_zip_stream')
     def test_attempt_fetch_and_write_new_zip_file_exists_already(self, mock_get_etag, mock_datetime):
         mock_get_etag.return_value = (self.etag, self.make_mock_response())
-        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
+        now, expected_result = self.make_now_and_expected_result(voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
         mock_datetime.now.return_value = now
         # create a FileTracker with this etag value -> CODE_NOTHING_TO_DO
         FileTracker.objects.create(etag=self.etag, created=now)
-        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        result = voter_fetch_snapshot.attempt_fetch_and_write_new_zip(self.url, self.base_path)
         self.assertEqual(result, expected_result)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.write_stream')
@@ -109,11 +107,11 @@ class VoterFetchTest(TestCase):
     @mock.patch('voter.management.commands.voter_fetch_snapshot.get_etag_and_zip_stream')
     def test_attempt_fetch_and_write_new_zip(self, mock_get_etag, mock_datetime, mock_write_stream):
         mock_get_etag.return_value = (self.etag, self.make_mock_response())
-        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_OK)
+        now, expected_result = self.make_now_and_expected_result(voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_OK)
         mock_datetime.now.return_value = now
         # write is successful -> CODE_OK
         mock_write_stream.return_value = True
-        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        result = voter_fetch_snapshot.attempt_fetch_and_write_new_zip(self.url, self.base_path)
         self.assertEqual(result, expected_result)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.write_stream')
@@ -121,11 +119,11 @@ class VoterFetchTest(TestCase):
     @mock.patch('voter.management.commands.voter_fetch_snapshot.get_etag_and_zip_stream')
     def test_attempt_fetch_and_write_new_zip_write_failure(self, mock_get_etag, mock_datetime, mock_write_stream):
         mock_get_etag.return_value = (self.etag, self.make_mock_response())
-        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+        now, expected_result = self.make_now_and_expected_result(voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
         mock_datetime.now.return_value = now
         # write failure -> CODE_WRITE_FAILURE
         mock_write_stream.return_value = False
-        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        result = voter_fetch_snapshot.attempt_fetch_and_write_new_zip(self.url, self.base_path)
         self.assertEqual(result, expected_result)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.datetime')
@@ -133,20 +131,20 @@ class VoterFetchTest(TestCase):
     def test_attempt_fetch_and_write_new_zip_net_failure(self, mock_get_etag, mock_datetime):
         # status_code != 200 -> CODE_NET_FAILURE
         mock_get_etag.return_value = (self.etag, self.make_mock_response(status_code=500))
-        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_NET_FAILURE)
+        now, expected_result = self.make_now_and_expected_result(voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_NET_FAILURE)
         mock_datetime.now.return_value = now
-        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        result = voter_fetch_snapshot.attempt_fetch_and_write_new_zip(self.url, self.base_path)
         self.assertEqual(result, expected_result)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.os.listdir')
     @mock.patch('voter.management.commands.voter_fetch_snapshot.extract_and_remove_file')
     @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
     def test_process_new_zip(self, mock_fetch, mock_extract, mock_listdir):
-        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_OK, self.etag, timezone.now(), ''
+        mock_fetch.return_value = voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_OK, self.etag, timezone.now(), ''
         mock_extract.return_value = True
         mock_listdir.return_value = ['bar.txt', 'ignored.foo']
-        result = process_new_zip(self.url, self.base_path, self.label)
-        self.assertEqual(result, FETCH_STATUS_CODES.CODE_OK)
+        result = voter_fetch_snapshot.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_OK)
         # FileTracker for .txt file gets created ...
         self.assertTrue(FileTracker.objects.filter(filename='bar.txt').exists())
         # ... but we ignore files that don't have a .txt extension
@@ -155,28 +153,28 @@ class VoterFetchTest(TestCase):
     @mock.patch('voter.management.commands.voter_fetch_snapshot.extract_and_remove_file')
     @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
     def test_process_new_zip_unable_to_unzip(self, mock_fetch, mock_extract):
-        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_OK, None, None, None
+        mock_fetch.return_value = voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_OK, None, None, None
         mock_extract.return_value = False
-        result = process_new_zip(self.url, self.base_path, self.label)
-        self.assertEqual(result, FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+        result = voter_fetch_snapshot.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
     def test_process_new_zip_already_downloaded(self, mock_fetch):
-        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_NOTHING_TO_DO, None, None, None
-        result = process_new_zip(self.url, self.base_path, self.label)
-        self.assertEqual(result, FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
+        mock_fetch.return_value = voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_NOTHING_TO_DO, None, None, None
+        result = voter_fetch_snapshot.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
     def test_process_new_zip_net_failure(self, mock_fetch):
-        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_NET_FAILURE, None, None, None
-        result = process_new_zip(self.url, self.base_path, self.label)
-        self.assertEqual(result, FETCH_STATUS_CODES.CODE_NET_FAILURE)
+        mock_fetch.return_value = voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_NET_FAILURE, None, None, None
+        result = voter_fetch_snapshot.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_NET_FAILURE)
 
     @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
     def test_process_new_zip_write_failure(self, mock_fetch):
-        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_WRITE_FAILURE, None, None, None
-        result = process_new_zip(self.url, self.base_path, self.label)
-        self.assertEqual(result, FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+        mock_fetch.return_value = voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_WRITE_FAILURE, None, None, None
+        result = voter_fetch_snapshot.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch_snapshot.FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
 
     # Finally, test the management command itself
 
@@ -211,3 +209,204 @@ class VoterFetchTest(TestCase):
                                                   {'Key': 'http://example.com/bar.txt'}]}
         call_command('voter_fetch_snapshot')
         self.assertEqual(mock_process_new_zip.call_count, 0)
+
+
+class VoterFetchCurrentTest(TestCase):
+
+    def setUp(self):
+        self.url = 'http://example.com/file.zip'
+        self.base_path = 'foo'
+        self.etag = 'a made-up etag value'
+        self.label = 'ncvoter'
+
+    def test_derive_target_folder(self):
+        "creates a folder path given a base_path and a date"
+        now = timezone.now()
+        expected_result = '{}/{}'.format(self.base_path, now.strftime('%Y-%m-%dT%H:%M:%S:%s'))
+        result = voter_fetch.derive_target_folder(self.base_path, now)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch.requests.get')
+    def test_get_etag_and_zip_stream(self, mock_get):
+        "returns the URL response and its etag header"
+        mock_response = mock_get.return_value
+        mock_response.headers = {'etag': self.etag}
+        result = voter_fetch.get_etag_and_zip_stream(self.url)
+        self.assertEqual(result, (self.etag, mock_response))
+
+    @mock.patch('voter.management.commands.voter_fetch.os.makedirs')
+    def test_write_stream(self, mock_mkdirs):
+        "mock that we can write a response to a mock file"
+        mock_open = mock.mock_open()
+        rsp = mock.Mock()
+        rsp.headers = {'content-length': 1}
+        rsp.iter_content.return_value = ['some', 'content']
+        filename = 'foo/bar.txt'
+        with mock.patch('voter.management.commands.voter_fetch.open', mock_open, create=True):
+            result = voter_fetch.write_stream(rsp, filename)
+        mock_open.assert_called_once_with(filename, 'wb')
+        self.assertEqual(result, True)
+
+    def test_write_stream_ioerror(self):
+        "IOError returns False"
+        rsp = mock.Mock()
+        # filename at root of filesystem should not be writable, so will generate IOError
+        filename = '/foo.txt'
+        result = voter_fetch.write_stream(rsp, filename)
+        self.assertEqual(result, False)
+
+    @mock.patch('voter.management.commands.voter_fetch.subprocess.call')
+    @mock.patch('voter.management.commands.voter_fetch.os.remove')
+    def test_extract_and_remove_file(self, mock_remove, mock_unzip):
+        mock_unzip.return_value = 0
+        filename = 'foo/bar.zip'
+        result = voter_fetch.extract_and_remove_file(filename)
+        self.assertEqual(result, True)
+        mock_unzip.assert_called_once_with(['unzip', filename, '-d', 'foo'])
+        mock_remove.assert_called_once_with(filename)
+
+    @mock.patch('voter.management.commands.voter_fetch.os.remove')
+    def test_extract_and_remove_file_ioerror(self, mock_remove):
+        filename = 'foo/bar.zip'
+        result = voter_fetch.extract_and_remove_file(filename)
+        self.assertEqual(result, False)
+        # unzip failed, so we shouldn't have tried to remove the file
+        mock_remove.assert_not_called()
+
+    # helpers for attempt_fetch_and_write_new_zip testing
+
+    def make_mock_response(self, status_code=200):
+        rsp = mock.Mock(status_code=status_code,
+                        headers={'content-length': 1})
+        rsp.iter_content.return_value = []
+        return rsp
+
+    def make_now_and_expected_result(self, fetch_status_code):
+        now = timezone.now()
+        target_filename = '{}/{}/{}'.format(
+            self.base_path, now.strftime('%Y-%m-%dT%H:%M:%S:%s'), self.url.split('/')[-1])
+        expected_result = (
+            fetch_status_code,
+            self.etag,
+            now,
+            target_filename,
+        )
+        return now, expected_result
+
+    @mock.patch('voter.management.commands.voter_fetch.datetime')
+    @mock.patch('voter.management.commands.voter_fetch.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip_file_exists_already(self, mock_get_etag, mock_datetime):
+        mock_get_etag.return_value = (self.etag, self.make_mock_response())
+        now, expected_result = self.make_now_and_expected_result(voter_fetch.FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
+        mock_datetime.now.return_value = now
+        # create a FileTracker with this etag value -> CODE_NOTHING_TO_DO
+        FileTracker.objects.create(etag=self.etag, created=now)
+        result = voter_fetch.attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch.write_stream')
+    @mock.patch('voter.management.commands.voter_fetch.datetime')
+    @mock.patch('voter.management.commands.voter_fetch.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip(self, mock_get_etag, mock_datetime, mock_write_stream):
+        mock_get_etag.return_value = (self.etag, self.make_mock_response())
+        now, expected_result = self.make_now_and_expected_result(voter_fetch.FETCH_STATUS_CODES.CODE_OK)
+        mock_datetime.now.return_value = now
+        # write is successful -> CODE_OK
+        mock_write_stream.return_value = True
+        result = voter_fetch.attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch.write_stream')
+    @mock.patch('voter.management.commands.voter_fetch.datetime')
+    @mock.patch('voter.management.commands.voter_fetch.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip_write_failure(self, mock_get_etag, mock_datetime, mock_write_stream):
+        mock_get_etag.return_value = (self.etag, self.make_mock_response())
+        now, expected_result = self.make_now_and_expected_result(voter_fetch.FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+        mock_datetime.now.return_value = now
+        # write failure -> CODE_WRITE_FAILURE
+        mock_write_stream.return_value = False
+        result = voter_fetch.attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch.datetime')
+    @mock.patch('voter.management.commands.voter_fetch.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip_net_failure(self, mock_get_etag, mock_datetime):
+        # status_code != 200 -> CODE_NET_FAILURE
+        mock_get_etag.return_value = (self.etag, self.make_mock_response(status_code=500))
+        now, expected_result = self.make_now_and_expected_result(voter_fetch.FETCH_STATUS_CODES.CODE_NET_FAILURE)
+        mock_datetime.now.return_value = now
+        result = voter_fetch.attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch.os.listdir')
+    @mock.patch('voter.management.commands.voter_fetch.extract_and_remove_file')
+    @mock.patch('voter.management.commands.voter_fetch.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip(self, mock_fetch, mock_extract, mock_listdir):
+        mock_fetch.return_value = voter_fetch.FETCH_STATUS_CODES.CODE_OK, self.etag, timezone.now(), ''
+        mock_extract.return_value = True
+        mock_listdir.return_value = ['bar.txt', 'ignored.foo']
+        result = voter_fetch.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch.FETCH_STATUS_CODES.CODE_OK)
+        # FileTracker for .txt file gets created ...
+        self.assertTrue(FileTracker.objects.filter(filename='bar.txt').exists())
+        # ... but we ignore files that don't have a .txt extension
+        self.assertFalse(FileTracker.objects.filter(filename='ignored.foo').exists())
+
+    @mock.patch('voter.management.commands.voter_fetch.os.listdir')
+    @mock.patch('voter.management.commands.voter_fetch.extract_and_remove_file')
+    @mock.patch('voter.management.commands.voter_fetch.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_ncvhis(self, mock_fetch, mock_extract, mock_listdir):
+        mock_fetch.return_value = voter_fetch.FETCH_STATUS_CODES.CODE_OK, self.etag, timezone.now(), ''
+        mock_extract.return_value = True
+        mock_listdir.return_value = ['bar.txt', 'ignored.foo']
+        result = voter_fetch.process_new_zip(self.url, self.base_path, 'ncvhis')
+        self.assertEqual(result, voter_fetch.FETCH_STATUS_CODES.CODE_OK)
+        # FileTracker for .txt file gets created ...
+        self.assertTrue(FileTracker.objects.filter(filename='bar.txt').exists())
+        # ... but we ignore files that don't have a .txt extension
+        self.assertFalse(FileTracker.objects.filter(filename='ignored.foo').exists())
+
+    @mock.patch('voter.management.commands.voter_fetch.extract_and_remove_file')
+    @mock.patch('voter.management.commands.voter_fetch.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_unable_to_unzip(self, mock_fetch, mock_extract):
+        mock_fetch.return_value = voter_fetch.FETCH_STATUS_CODES.CODE_OK, None, None, None
+        mock_extract.return_value = False
+        result = voter_fetch.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch.FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+
+    @mock.patch('voter.management.commands.voter_fetch.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_already_downloaded(self, mock_fetch):
+        mock_fetch.return_value = voter_fetch.FETCH_STATUS_CODES.CODE_NOTHING_TO_DO, None, None, None
+        result = voter_fetch.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch.FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
+
+    @mock.patch('voter.management.commands.voter_fetch.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_net_failure(self, mock_fetch):
+        mock_fetch.return_value = voter_fetch.FETCH_STATUS_CODES.CODE_NET_FAILURE, None, None, None
+        result = voter_fetch.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch.FETCH_STATUS_CODES.CODE_NET_FAILURE)
+
+    @mock.patch('voter.management.commands.voter_fetch.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_write_failure(self, mock_fetch):
+        mock_fetch.return_value = voter_fetch.FETCH_STATUS_CODES.CODE_WRITE_FAILURE, None, None, None
+        result = voter_fetch.process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, voter_fetch.FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+
+    @mock.patch('voter.management.commands.voter_fetch.process_new_zip')
+    def test_handle(self, mock_process_new_zip):
+        call_command('voter_fetch')
+        expected_url1 = settings.NCVOTER_LATEST_STATEWIDE_URL
+        expected_url2 = settings.NCVHIS_LATEST_STATEWIDE_URL
+        expected = [
+            # mock records tuples of (args, kwargs), but we don't send kwargs in our commands
+            ((expected_url1, settings.NCVOTER_DOWNLOAD_PATH, 'ncvoter', None), {}),
+            ((expected_url2, settings.NCVHIS_DOWNLOAD_PATH, 'ncvhis', None), {}),
+        ]
+        self.assertEqual(mock_process_new_zip.call_args_list, expected)
+
+    @mock.patch('voter.management.commands.voter_fetch.process_new_zip')
+    def test_handle_county(self, mock_process_new_zip):
+        call_command('voter_fetch', '--bycounty')
+        # don't do in-depth testing, just check that we try to process 200 files
+        #   100 counties x 2 files per county (ncvoter and ncvhis)
+        self.assertEqual(mock_process_new_zip.call_count, 200)

--- a/voter/tests/test_fetch.py
+++ b/voter/tests/test_fetch.py
@@ -1,0 +1,213 @@
+from unittest import mock
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from voter.models import FileTracker
+from voter.management.commands.voter_fetch_snapshot import derive_target_folder, get_etag_and_zip_stream, \
+    write_stream, extract_and_remove_file, attempt_fetch_and_write_new_zip, FETCH_STATUS_CODES, \
+    process_new_zip
+
+
+class VoterFetchTest(TestCase):
+
+    def setUp(self):
+        self.url = 'http://example.com/file.zip'
+        self.base_path = 'foo'
+        self.etag = 'a made-up etag value'
+        self.label = 'ncvoter'
+
+    def test_derive_target_folder(self):
+        "creates a folder path given a base_path and a date"
+        now = timezone.now()
+        expected_result = '{}/{}'.format(self.base_path, now.strftime('%Y-%m-%dT%H:%M:%S:%s'))
+        result = derive_target_folder(self.base_path, now)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.requests.get')
+    def test_get_etag_and_zip_stream(self, mock_get):
+        "returns the URL response and its etag header"
+        mock_response = mock_get.return_value
+        mock_response.headers = {'etag': self.etag}
+        result = get_etag_and_zip_stream(self.url)
+        self.assertEqual(result, (self.etag, mock_response))
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.os.makedirs')
+    def test_write_stream(self, mock_mkdirs):
+        "mock that we can write a response to a mock file"
+        mock_open = mock.mock_open()
+        rsp = mock.Mock()
+        rsp.headers = {'content-length': 1}
+        rsp.iter_content.return_value = ['some', 'content']
+        filename = 'foo/bar.txt'
+        with mock.patch('voter.management.commands.voter_fetch_snapshot.open', mock_open, create=True):
+            result = write_stream(rsp, filename)
+        mock_open.assert_called_once_with(filename, 'wb')
+        self.assertEqual(result, True)
+
+    def test_write_stream_ioerror(self):
+        "IOError returns False"
+        rsp = mock.Mock()
+        # filename at root of filesystem should not be writable, so will generate IOError
+        filename = '/foo.txt'
+        result = write_stream(rsp, filename)
+        self.assertEqual(result, False)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.subprocess.call')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.os.remove')
+    def test_extract_and_remove_file(self, mock_remove, mock_unzip):
+        mock_unzip.return_value = 0
+        filename = 'foo/bar.zip'
+        result = extract_and_remove_file(filename)
+        self.assertEqual(result, True)
+        mock_unzip.assert_called_once_with(['unzip', filename, '-d', 'foo'])
+        mock_remove.assert_called_once_with(filename)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.os.remove')
+    def test_extract_and_remove_file_ioerror(self, mock_remove):
+        filename = 'foo/bar.zip'
+        result = extract_and_remove_file(filename)
+        self.assertEqual(result, False)
+        # unzip failed, so we shouldn't have tried to remove the file
+        mock_remove.assert_not_called()
+
+    # helpers for attempt_fetch_and_write_new_zip testing
+
+    def make_mock_response(self, status_code=200):
+        rsp = mock.Mock(status_code=status_code,
+                        headers={'content-length': 1})
+        rsp.iter_content.return_value = []
+        return rsp
+
+    def make_now_and_expected_result(self, fetch_status_code):
+        now = timezone.now()
+        target_filename = '{}/{}/{}'.format(
+            self.base_path, now.strftime('%Y-%m-%dT%H:%M:%S:%s'), self.url.split('/')[-1])
+        expected_result = (
+            fetch_status_code,
+            self.etag,
+            now,
+            target_filename,
+        )
+        return now, expected_result
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.datetime')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip_file_exists_already(self, mock_get_etag, mock_datetime):
+        mock_get_etag.return_value = (self.etag, self.make_mock_response())
+        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
+        mock_datetime.now.return_value = now
+        # create a FileTracker with this etag value -> CODE_NOTHING_TO_DO
+        FileTracker.objects.create(etag=self.etag, created=now)
+        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.write_stream')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.datetime')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip(self, mock_get_etag, mock_datetime, mock_write_stream):
+        mock_get_etag.return_value = (self.etag, self.make_mock_response())
+        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_OK)
+        mock_datetime.now.return_value = now
+        # write is successful -> CODE_OK
+        mock_write_stream.return_value = True
+        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.write_stream')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.datetime')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip_write_failure(self, mock_get_etag, mock_datetime, mock_write_stream):
+        mock_get_etag.return_value = (self.etag, self.make_mock_response())
+        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+        mock_datetime.now.return_value = now
+        # write failure -> CODE_WRITE_FAILURE
+        mock_write_stream.return_value = False
+        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.datetime')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.get_etag_and_zip_stream')
+    def test_attempt_fetch_and_write_new_zip_net_failure(self, mock_get_etag, mock_datetime):
+        # status_code != 200 -> CODE_NET_FAILURE
+        mock_get_etag.return_value = (self.etag, self.make_mock_response(status_code=500))
+        now, expected_result = self.make_now_and_expected_result(FETCH_STATUS_CODES.CODE_NET_FAILURE)
+        mock_datetime.now.return_value = now
+        result = attempt_fetch_and_write_new_zip(self.url, self.base_path)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.os.listdir')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.extract_and_remove_file')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip(self, mock_fetch, mock_extract, mock_listdir):
+        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_OK, self.etag, timezone.now(), ''
+        mock_extract.return_value = True
+        mock_listdir.return_value = ['bar.txt', 'ignored.foo']
+        result = process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, FETCH_STATUS_CODES.CODE_OK)
+        # FileTracker for .txt file gets created ...
+        self.assertTrue(FileTracker.objects.filter(filename='bar.txt').exists())
+        # ... but we ignore files that don't have a .txt extension
+        self.assertFalse(FileTracker.objects.filter(filename='ignored.foo').exists())
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.extract_and_remove_file')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_unable_to_unzip(self, mock_fetch, mock_extract):
+        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_OK, None, None, None
+        mock_extract.return_value = False
+        result = process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_already_downloaded(self, mock_fetch):
+        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_NOTHING_TO_DO, None, None, None
+        result = process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, FETCH_STATUS_CODES.CODE_NOTHING_TO_DO)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_net_failure(self, mock_fetch):
+        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_NET_FAILURE, None, None, None
+        result = process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, FETCH_STATUS_CODES.CODE_NET_FAILURE)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.attempt_fetch_and_write_new_zip')
+    def test_process_new_zip_write_failure(self, mock_fetch):
+        mock_fetch.return_value = FETCH_STATUS_CODES.CODE_WRITE_FAILURE, None, None, None
+        result = process_new_zip(self.url, self.base_path, self.label)
+        self.assertEqual(result, FETCH_STATUS_CODES.CODE_WRITE_FAILURE)
+
+    # Finally, test the management command itself
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.process_new_zip')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.s3client.list_objects')
+    def test_handle(self, mock_s3_list, mock_process_new_zip):
+        mock_s3_list.return_value = {'Contents': [{'Key': 'http://example.com/foo.zip'}]}
+        call_command('voter_fetch_snapshot')
+        expected_url = settings.NCVOTER_HISTORICAL_SNAPSHOT_URL + 'foo.zip'
+        mock_process_new_zip.assert_called_once_with(expected_url, settings.NCVOTER_DOWNLOAD_PATH, 'ncvoter')
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.process_new_zip')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.s3client.list_objects')
+    def test_handle_multiple_files(self, mock_s3_list, mock_process_new_zip):
+        mock_s3_list.return_value = {'Contents': [{'Key': 'http://example.com/foo.zip'},
+                                                  {'Key': 'http://example.com/bar.zip'}]}
+        call_command('voter_fetch_snapshot')
+        # We re-order alphabetically by the filename, so bar.zip comes before foo.zip
+        expected_url1 = settings.NCVOTER_HISTORICAL_SNAPSHOT_URL + 'bar.zip'
+        expected_url2 = settings.NCVOTER_HISTORICAL_SNAPSHOT_URL + 'foo.zip'
+        expected = [
+            # mock records tuples of (args, kwargs), but we don't send kwargs in our commands
+            ((expected_url1, settings.NCVOTER_DOWNLOAD_PATH, 'ncvoter'), {}),
+            ((expected_url2, settings.NCVOTER_DOWNLOAD_PATH, 'ncvoter'), {}),
+        ]
+        self.assertEqual(mock_process_new_zip.call_args_list, expected)
+
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.process_new_zip')
+    @mock.patch('voter.management.commands.voter_fetch_snapshot.s3client.list_objects')
+    def test_handle_skip_non_zip_files(self, mock_s3_list, mock_process_new_zip):
+        mock_s3_list.return_value = {'Contents': [{'Key': 'http://example.com/foo.txt'},
+                                                  {'Key': 'http://example.com/bar.txt'}]}
+        call_command('voter_fetch_snapshot')
+        self.assertEqual(mock_process_new_zip.call_count, 0)


### PR DESCRIPTION
* Adds coverage of the voter_fetch_snapshot management command
* Moves 'directory creation' to the write_stream function for easier testing (less mocking)
* Fixed the error checking around file unzipping (`subprocess.call()` doesn't raise IOError)
* Removed the check for DB failure since I can't see a way to get to that code (I think Django would raise an error instead)
* Reworked docs about `--all` since they were inaccurate
* Fixed a timezone warning in test_api.py

Second commit adds the same tests for the voter_fetch management command.

Once this PR is merged, I'll do the following:
* pull out all the shared code between voter_fetch.py and voter_fetch_snapshot.py, which should make each management command much smaller
* add tests for the different functionality of voter_fetch.py
* add docs about how/when to use each
* update the cron tequila code