### PR TITLE
Send cron output to syslog

### DIFF
--- a/deployment/playbooks/cron.yml
+++ b/deployment/playbooks/cron.yml
@@ -9,4 +9,5 @@
       hour: 2
       minute: 0
       user: "{{ project_name }}"
-      job: cd /var/www/{{ project_name }}; ./manage.sh voter_fetch; ./manage.sh voter_process_snapshot
+      # send output to syslog: https://serverfault.com/a/434902/218035
+      job: cd /var/www/{{ project_name }}; ./manage.sh voter_fetch 2>&1 | /usr/bin/logger -t voter_fetch; ./manage.sh voter_process_snapshot 2>&1 | /usr/bin/logger -t voter_process


### PR DESCRIPTION
Not sure if it's better to create 2 separate cron entries for clarity? 