### PR TITLE
Stop spamming Sentry

### DIFF
--- a/voter/management/commands/voter_process_snapshot.py
+++ b/voter/management/commands/voter_process_snapshot.py
@@ -157,14 +157,7 @@ def find_existing_instance(ncid):
 
     Will prefetch all ChangeTracker instances related."""
 
-    voter = NCVoter.objects.filter(ncid=ncid).prefetch_related('changelog').first()
-    if voter:
-        if not voter.changelog.filter(op_code=ChangeTracker.OP_CODE_ADD).exists():
-            # This should not happen, but logging it just spams sentry.
-            # logger.error('Voter has no ADD ChangeTracker: %s', voter.ncid)
-            pass
-
-    return voter
+    return NCVoter.objects.filter(ncid=ncid).prefetch_related('changelog').first()
 
 
 @transaction.atomic

--- a/voter/management/commands/voter_process_snapshot.py
+++ b/voter/management/commands/voter_process_snapshot.py
@@ -160,7 +160,9 @@ def find_existing_instance(ncid):
     voter = NCVoter.objects.filter(ncid=ncid).prefetch_related('changelog').first()
     if voter:
         if not voter.changelog.filter(op_code=ChangeTracker.OP_CODE_ADD).exists():
-            logger.error('Voter has no ADD ChangeTracker: %s', voter.ncid)
+            # This should not happen, but logging it just spams sentry.
+            # logger.error('Voter has no ADD ChangeTracker: %s', voter.ncid)
+            pass
 
     return voter
 


### PR DESCRIPTION
We should probably just remove the `op_code` since the first ChangeTracker instance is implicitly the 'add', but for now this will stop us from sending error reports to sentry.