### PR TITLE
Remove extra division

### DIFF
--- a/matview/management/commands/refresh_matviews.py
+++ b/matview/management/commands/refresh_matviews.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
 
             instance = kwargs.get('instance')
             if instance:
-                delta = (instance.last_updated - instance._last_started).microseconds / 1000
+                delta = (instance.last_updated - instance._last_started).microseconds
                 t = int(delta / options['threads'])
                 if t >= 1000:
                     ts = "%0.1fs" % (t / 1000,)


### PR DESCRIPTION
I think `delta` should be in microseconds because we then check on line 48 if it's greater than 1000, and if so, label it seconds.

Seeing output like this on prod, despite each step taking about a minute to return:
```
matview_mv_voter_ncvoter_county_desc_moore [191ms 45/114]
matview_mv_voter_ncvoter_county_desc_graham [119ms 46/114]
matview_mv_voter_ncvoter_county_desc_nash [123ms 47/114]
matview_mv_voter_ncvoter_county_desc_granville [131ms 48/114]
matview_mv_voter_ncvoter_county_desc_greene [217ms 49/114]
matview_mv_voter_ncvoter_county_desc_wayne [130ms 50/114]
matview_mv_voter_ncvoter_county_desc_wilkes [14ms 51/114]
```