### PR TITLE
DIS-307 Show phone number more reliably

### DIFF
--- a/drilldown/templates/drilldown/sample.html
+++ b/drilldown/templates/drilldown/sample.html
@@ -40,7 +40,7 @@
                         <td>{{ v.data.mail_addr1 }}</td>
                         <td>{{ v.data.mail_city }}</td>
                         <td>{{ v.data.mail_zipcode }}</td>
-                        <td>{{ v.data.area_cd }} {{ v.data.phone_num }}</td>
+                        <td>{% if v.data.full_phone_number %}{{ v.data.full_phone_number }}{% else %}{{ v.data.area_cd }} {{ v.data.phone_num }}{% endif %}</td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
* Newer snapshots store phone number in `full_phone_number`.
* Older snapshots store it in `area_cd` + `phone_num`, though some have only 1 of those fields (sigh).
* But AFAICT, there are no other records which would store a phone number.
```
ncvoter_production=> select data from voter_ncvoter where not data ? 'area_cd' and not data ? 'full_phone_number' and not data ? 'phone_num' and data::text like '%phone%' limit 1;
 data 
------
(0 rows)
```
The other problem is that only about 4.4 million of the records have either of the above, so a majority of records don't have any phone.